### PR TITLE
Yeti parameters

### DIFF
--- a/fwMatch-darpa/expt/crf_parameters.ini
+++ b/fwMatch-darpa/expt/crf_parameters.ini
@@ -57,3 +57,11 @@ yeti_grid_ppn = 2
 yeti_grid_walltime = 12:00:00
 # Memory to request in mb
 yeti_grid_mem = 8000
+
+[YetiGenerateShuffledOptions]
+yeti_gen_sh_nodes = 1
+yeti_gen_sh_ppn = 1
+# Walltime read in as a string and passed verbatim
+yeti_gen_sh_walltime = 02:00:00
+# Memory to request in mb
+yeti_gen_sh_mem = 4000

--- a/fwMatch-darpa/expt/crf_parameters.ini
+++ b/fwMatch-darpa/expt/crf_parameters.ini
@@ -2,6 +2,8 @@
 experiment_name = experiment
 data_directory = ~/data/
 source_directory = ~/graph_ensemble/
+# Set verbosity higher to receive more logging output, lower to receive less
+verbosity = 3
 
 ### BEGIN GridsearchOptions ###
 [S_LAMBDAS]

--- a/fwMatch-darpa/expt/crf_parameters.ini
+++ b/fwMatch-darpa/expt/crf_parameters.ini
@@ -3,23 +3,6 @@ experiment_name = experiment
 data_directory = ~/data/
 source_directory = ~/graph_ensemble/
 
-[YetiOptions]
-username = UNI
-email = UNI@columbia.edu
-# If email_notification = num_jobs, the level of email notifications will be determined
-# by the number of jobs being submitted. Otherwise, the option will be passed verbatim
-email_notification = num_jobs
-# If email_notification = num_jobs, submissions with more than this many jobs
-# will not send emails for normal termination.
-email_jobs_threshold = 10
-groupID = GROUPID
-yeti_nodes = 1
-yeti_ppn = 2
-# Walltime read in as a string and passed verbatim
-yeti_walltime = 12:00:00
-# Memory to request in mb
-yeti_mem = 8000
-
 ### BEGIN GridsearchOptions ###
 [S_LAMBDAS]
 # If parallize is True, each point generates a distinct config and job
@@ -50,3 +33,27 @@ max = 1e+04
 time_span = 2
 # Number of control datasets to create and model
 num_shuffle = 100
+
+[YetiOptions]
+# General yeti options
+
+# ***MANDATORY*** when using the yeti cluster scripts
+# Update to your username, group ID, and email address
+username = UNI
+group_id = GROUPID
+email = UNI@columbia.edu
+
+# If email_notification = num_jobs, the level of email notifications will be determined
+# by the number of jobs being submitted. Otherwise, the option will be passed verbatim
+email_notification = num_jobs
+# If email_notification = num_jobs, submissions with more than this many jobs
+# will not send emails for normal termination.
+email_jobs_threshold = 10
+
+[YetiGridsearchOptions]
+yeti_grid_nodes = 1
+yeti_grid_ppn = 2
+# Walltime read in as a string and passed verbatim
+yeti_grid_walltime = 12:00:00
+# Memory to request in mb
+yeti_grid_mem = 8000

--- a/fwMatch-darpa/expt/crf_parameters.ini
+++ b/fwMatch-darpa/expt/crf_parameters.ini
@@ -67,3 +67,13 @@ yeti_gen_sh_ppn = 1
 yeti_gen_sh_walltime = 02:00:00
 # Memory to request in mb
 yeti_gen_sh_mem = 4000
+
+[YetiShuffledControlsOptions]
+yeti_sh_ctrl_nodes = 1
+yeti_sh_ctrl_ppn = 1
+# Walltime read in as a string and passed verbatim
+yeti_sh_ctrl_walltime = 02:00:00
+# Memory to request in mb
+yeti_sh_ctrl_mem = 8000
+
+### END Yeti Options ###

--- a/fwMatch-darpa/expt/crf_parameters.ini
+++ b/fwMatch-darpa/expt/crf_parameters.ini
@@ -6,6 +6,19 @@ source_directory = ~/graph_ensemble/
 [YetiOptions]
 username = UNI
 email = UNI@columbia.edu
+# If email_notification = num_jobs, the level of email notifications will be determined
+# by the number of jobs being submitted. Otherwise, the option will be passed verbatim
+email_notification = num_jobs
+# If email_notification = num_jobs, submissions with more than this many jobs
+# will not send emails for normal termination.
+email_jobs_threshold = 10
+groupID = GROUPID
+yeti_nodes = 1
+yeti_ppn = 2
+# Walltime read in as a string and passed verbatim
+yeti_walltime = 12:00:00
+# Memory to request in mb
+yeti_mem = 8000
 
 ### BEGIN GridsearchOptions ###
 [S_LAMBDAS]
@@ -35,6 +48,5 @@ max = 1e+04
 
 [OtherOptions]
 time_span = 2
-
 # Number of control datasets to create and model
 num_shuffle = 100

--- a/fwMatch-darpa/expt/crf_util.py
+++ b/fwMatch-darpa/expt/crf_util.py
@@ -11,6 +11,10 @@ logger.addHandler(logging.StreamHandler(stream=sys.stdout))
 logger.setLevel(logging.INFO)
 
 
+def loglevel_from_verbosity(verbosity):
+    return max([logging.CRITICAL - (verbosity * 10), logging.DEBUG])
+
+
 def get_raw_configparser(fname="crf_parameters.ini"):
     config = configparser.ConfigParser()
     config.read(fname)

--- a/fwMatch-darpa/expt/gridsearch_train_crfs.py
+++ b/fwMatch-darpa/expt/gridsearch_train_crfs.py
@@ -111,7 +111,6 @@ def create_yeti_config_sh(name, params):
             # Use email_notification setting verbatim
             f.write("#PBS -m {}\n".format(params['email_notification']))
         f.write("#PBS -M {}\n".format(params['email']))
-        f.write("#PBS -V\n")
         f.write("#PBS -t 1-{}\n".format(int(num_jobs)))
 
         working_dir = os.path.join(params['expt_dir'], params['experiment'])

--- a/fwMatch-darpa/expt/gridsearch_train_crfs.py
+++ b/fwMatch-darpa/expt/gridsearch_train_crfs.py
@@ -13,10 +13,6 @@ import logging
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.StreamHandler(stream=sys.stdout))
 
-# *** START USER EDITABLE VARIABLES ***
-logger.setLevel(logging.INFO)
-# *** END USER EDITABLE VARIABLES ***
-
 # *** start constants ***
 MODEL_TYPE = "loopy"
 
@@ -31,6 +27,7 @@ def get_conditions_metadata(conditions):
     parameters = crf_util.get_GridsearchOptions(parser=parameters_parser)
     parameters.update(crf_util.get_OtherOptions(parser=parameters_parser))
     parameters.update(crf_util.get_section_options('GeneralOptions', parser=parameters_parser))
+    logger.setLevel(crf_util.loglevel_from_verbosity(int(parameters['verbosity'])))
     parameters.update(crf_util.get_section_options('YetiOptions', parser=parameters_parser))
     parameters.update(crf_util.get_section_options('YetiGridsearchOptions',
                                                    parser=parameters_parser))
@@ -173,7 +170,7 @@ def setup_exec_train_model(conditions):
         logger.info("\nTraining configs generated.")
 
         create_yeti_config_sh(name, params)
-        create_start_jobs_sh(params['experiment_name'])
+        create_start_jobs_sh(params['experiment'])
 
         process_results = subprocess.run(".{}start_jobs.sh".format(os.sep), shell=True)
         if process_results.returncode:

--- a/fwMatch-darpa/expt/gridsearch_train_crfs.py
+++ b/fwMatch-darpa/expt/gridsearch_train_crfs.py
@@ -94,7 +94,7 @@ def create_yeti_config_sh(name, params):
         f.write("#Torque script to run Matlab program\n")
 
         f.write("\n#Torque directives\n")
-        f.write("#PBS -N {}\n".format(params['experiment']))
+        f.write("#PBS -N Gridsearch_{}\n".format(params['experiment']))
         f.write("#PBS -W group_list={}\n".format(params['group_id']))
         f.write("#PBS -l nodes={}:ppn={},walltime={},mem={}mb\n".format(
             params['yeti_grid_nodes'], params['yeti_grid_ppn'],

--- a/fwMatch-darpa/expt/gridsearch_train_crfs.py
+++ b/fwMatch-darpa/expt/gridsearch_train_crfs.py
@@ -32,6 +32,8 @@ def get_conditions_metadata(conditions):
     parameters.update(crf_util.get_OtherOptions(parser=parameters_parser))
     parameters.update(crf_util.get_section_options('GeneralOptions', parser=parameters_parser))
     parameters.update(crf_util.get_section_options('YetiOptions', parser=parameters_parser))
+    parameters.update(crf_util.get_section_options('YetiGridsearchOptions',
+                                                   parser=parameters_parser))
     for name, cond in conditions.items():
         cond.update(parameters)
         metadata = {'data_file': "{}_{}.mat".format(cond['experiment_name'], name),
@@ -96,14 +98,15 @@ def create_yeti_config_sh(name, params):
 
         f.write("\n#Torque directives\n")
         f.write("#PBS -N {}\n".format(params['experiment']))
-        f.write("#PBS -W group_list={}\n".format(params['groupID']))
+        f.write("#PBS -W group_list={}\n".format(params['group_id']))
         f.write("#PBS -l nodes={}:ppn={},walltime={},mem={}mb\n".format(
-            params['yeti_nodes'], params['yeti_ppn'], params['yeti_walltime'], params['yeti_mem']))
+            params['yeti_grid_nodes'], params['yeti_grid_ppn'],
+            params['yeti_grid_walltime'], params['yeti_grid_mem']))
         if params['email_notification'] == "num_jobs":
             # Reduce email notifications for greater numbers of jobs
             if num_jobs == 1:
                 f.write("#PBS -m abe\n")
-            elif num_jobs <= params['email_jobs_threshold']:
+            elif num_jobs <= int(params['email_jobs_threshold']):
                 f.write("#PBS -m ae\n")
             else:
                 f.write("#PBS -m af\n")

--- a/fwMatch-darpa/expt/run_full_temporal.py
+++ b/fwMatch-darpa/expt/run_full_temporal.py
@@ -12,10 +12,6 @@ import logging
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.StreamHandler(stream=sys.stdout))
 
-# *** START USER EDITABLE VARIABLES ***
-logger.setLevel(logging.INFO)
-# *** END USER EDITABLE VARIABLES ***
-
 
 def merge_and_get_parameters(experiment, **kwargs):
     gridsearch_train_crfs.merge_save_train_models(experiment, kwargs['source_directory'])
@@ -31,6 +27,8 @@ if __name__ == '__main__':
         if len(conditions) > 1:
             raise ValueError("Multiple conditions not currently supported.")
         conditions = gridsearch_train_crfs.get_conditions_metadata(conditions)
+        verbosity = int(conditions[sys.argv[1]]['verbosity'])
+        logger.setLevel(crf_util.loglevel_from_verbosity(verbosity))
         conditions = shuffled_control_crfs.get_conditions_metadata(conditions)
         gridsearch_train_crfs.setup_exec_train_model(conditions)
         # Create bare-bones shuffle folder and create shuffled datasets

--- a/fwMatch-darpa/expt/shuffled_control_crfs.py
+++ b/fwMatch-darpa/expt/shuffled_control_crfs.py
@@ -15,10 +15,6 @@ import logging
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.StreamHandler(stream=sys.stdout))
 
-# *** START USER EDITABLE VARIABLES ***
-logger.setLevel(logging.INFO)
-# *** END USER EDITABLE VARIABLES ***
-
 # *** start constants ***
 MODEL_TYPE = "loopy"
 # *** end constants ***
@@ -29,6 +25,7 @@ def get_conditions_metadata(conditions):
     parameters = crf_util.get_GridsearchOptions(parser=parameters_parser)
     parameters.update(crf_util.get_OtherOptions(parser=parameters_parser))
     parameters.update(crf_util.get_section_options('GeneralOptions', parser=parameters_parser))
+    logger.setLevel(crf_util.loglevel_from_verbosity(int(parameters['verbosity'])))
     parameters.update(crf_util.get_section_options('YetiOptions', parser=parameters_parser))
     parameters.update(crf_util.get_section_options('YetiGenerateShuffledOptions',
                                                    parser=parameters_parser))

--- a/fwMatch-darpa/expt/shuffled_control_crfs.py
+++ b/fwMatch-darpa/expt/shuffled_control_crfs.py
@@ -78,7 +78,7 @@ def write_shuffling_yeti_script(params):
     with open(filepath, 'w') as f:
         f.write("#!/bin/sh\n")
         f.write("#shuffle_yeti_config.sh\n")
-        f.write("#PBS -N {}\n".format(params['shuffle_experiment']))
+        f.write("#PBS -N Create_shuffled_dataset_{}\n".format(params['shuffle_experiment']))
         f.write("#PBS -W group_list={}\n".format(params['group_id']))
         f.write("#PBS -l nodes={}:ppn={},walltime={},mem={}mb\n".format(
             params['yeti_gen_sh_nodes'], params['yeti_gen_sh_ppn'],

--- a/fwMatch-darpa/expt/shuffled_control_crfs.py
+++ b/fwMatch-darpa/expt/shuffled_control_crfs.py
@@ -88,7 +88,6 @@ def write_shuffling_yeti_script(params):
             # Use email_notification setting verbatim
             f.write("#PBS -m {}\n".format(params['email_notification']))
         f.write("#PBS -M {}\n".format(params['email']))
-        f.write("#PBS -V\n")
         f.write("#set output and error directories (SSCC example here)\n")
         log_folder = "{}/".format(os.path.join(params['shuffle_experiment_dir'], "yeti_logs"))
         os.makedirs(os.path.expanduser(log_folder), exist_ok=True)

--- a/fwMatch-darpa/expt/shuffled_control_crfs.py
+++ b/fwMatch-darpa/expt/shuffled_control_crfs.py
@@ -189,6 +189,7 @@ def create_shuffle_configs(conditions, best_params):
                                     add_path=params['source_directory'])
 
         create_controls_yeti_config_sh(name, params)
+        create_start_jobs_sh(params['shuffle_experiment'])
 
         os.chdir(curr_dir)
         logger.debug("changed back to dir: {}".format(os.getcwd()))
@@ -240,6 +241,24 @@ def create_controls_yeti_config_sh(name, params):
     # make sure file is executable:
     os.chmod(fname, stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH | os.stat(fname).st_mode)
     logger.info("Created " + fname + ".")
+
+
+def create_start_jobs_sh(experiment):
+    # Expect to be in the experiment folder already when writing this
+    # TODO: yeti specific
+    fname = "start_jobs.sh"
+    with open(fname, 'w') as f:
+        # Clear out any basic remainders from previous runs
+        f.write("rm -f ./results/result*.mat\n")
+        f.write("rm -f ./yeti_logs/*\n")
+        f.write("rm -f ./job_logs/*\n")
+        f.write("cd ../.. && qsub {}\n".format(
+            os.path.join("expt", experiment, "controls_yeti_config.sh")))
+    f.closed
+
+    # make sure file is executable
+    os.chmod(fname, stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH | os.stat(fname).st_mode)
+    logger.info("Created " + os.path.join(experiment, fname) + ".")
 
 
 def exec_shuffle_model(shuffle_experiment, **kwargs):

--- a/fwMatch-darpa/src/expt_framework/create_config_files.m
+++ b/fwMatch-darpa/src/expt_framework/create_config_files.m
@@ -169,19 +169,6 @@ function create_config_files(varargin)
 
 fclose(fid);
 
-% Kate: we should write the start_jobs.sh script, too, since it includes the experiment name var
-    fid = fopen('start_jobs.sh','w');
-
-    fprintf(fid,'#If you are having problem with line endings use ":set ff=unix" in vim\n\n');
-
-%Kate - I do not want to remove any of the already computed model files; do that manually
-fprintf(fid,'rm -f ./results/result*.mat\n');
-%fprintf(fid,'rm -f ./results/model_calcium.mat\n');
-fprintf(fid,'rm -f ./yeti_logs/*\n');
-fprintf(fid,'rm -f ./job_logs/*\n');
-
-fprintf(fid,'cd ../.. && qsub expt/%s/yeti_config.sh\n', experiment_name);
-fclose(fid);
 %Kate: make sure they are executable:
 system('chmod +x start_jobs.sh yeti_config.sh');
 

--- a/fwMatch-darpa/src/expt_framework/create_config_files.m
+++ b/fwMatch-darpa/src/expt_framework/create_config_files.m
@@ -127,50 +127,5 @@ function create_config_files(varargin)
         end
     end
 
-    % Write YETI script
-    fid = fopen('yeti_config.sh','w');
-
-    fprintf(fid,'#!/bin/sh\n');
-    fprintf(fid,'#yeti_config.sh\n\n');
-    fprintf(fid,'#Torque script to run Matlab program\n');
-
-    fprintf(fid,'\n#Torque directives\n');
-    fprintf(fid,'#PBS -N %s\n', experiment_name);
-    %fprintf(fid,'#PBS -W group_list=yetidsi\n'); -- Kate
-    fprintf(fid,'#PBS -W group_list=yetibrain\n');
-    if(strcmp( structure_type, 'loopy') == 1)
-      fprintf(fid,'#PBS -l nodes=1:ppn=2,walltime=12:00:00,mem=8000mb\n');
-    else
-      fprintf(fid,'#PBS -l nodes=1:ppn=1,walltime=12:00:00,mem=8000mb\n');
-    end
-   if(p_lambda_splits*s_lambda_splits*density_splits == 1)
-      fprintf(fid,'#PBS -m abe\n');
-    else
-        if(p_lambda_splits*s_lambda_splits*density_splits <= 10)
-              fprintf(fid,'#PBS -m ae\n');
-        else
-            fprintf(fid, '#PBS -m af\n');
-        end
-    end
-    fprintf(fid,'#PBS -M %s\n', email_for_notifications);
-    fprintf(fid,'#PBS -V\n');
-    fprintf(fid,'#PBS -t 1-%d\n',p_lambda_splits*s_lambda_splits*density_splits);
-
-    expt_dir = pwd;
-    run_dir = expt_dir(1:regexp(expt_dir, 'fwMatch-darpa/','end'));
-    fprintf(fid,'\n#set output and error directories (SSCC example here)\n');
-    fprintf(fid,'#PBS -o localhost:%s/yeti_logs/\n', expt_dir);
-    fprintf(fid,'#PBS -e localhost:%s/yeti_logs/\n', expt_dir);
-
-    fprintf(fid,'\n#Command below is to execute Matlab code for Job Array (Example 4) so that each part writes own output\n');
-    fprintf(fid,'cd %s\n', run_dir);
-    fprintf(fid,'./run.sh %s $PBS_ARRAYID > expt/%s/job_logs/matoutfile.$PBS_ARRAYID\n', experiment_name, experiment_name);
-    fprintf(fid,'#End of script\n');
-
-fclose(fid);
-
-%Kate: make sure they are executable:
-system('chmod +x start_jobs.sh yeti_config.sh');
-
 end
 

--- a/fwMatch-darpa/src/expt_framework/create_shuffle_config_files.m
+++ b/fwMatch-darpa/src/expt_framework/create_shuffle_config_files.m
@@ -125,38 +125,6 @@ function create_config_files(varargin)
         fclose(fid);
     end
 
-    % Write YETI script
-    fid = fopen('yeti_config.sh','w');
-
-    fprintf(fid,'#!/bin/sh\n');
-    fprintf(fid,'#yeti_config.sh\n\n');
-    fprintf(fid,'#Torque script to run Matlab program\n');
-
-    fprintf(fid,'\n#Torque directives\n');
-    fprintf(fid,'#PBS -N %s\n', experiment_name);
-    fprintf(fid,'#PBS -W group_list=yetibrain\n');
-    if(strcmp( structure_type, 'loopy') == 1)
-      fprintf(fid,'#PBS -l nodes=1:ppn=1,walltime=2:00:00,mem=8000mb\n');
-    else
-      fprintf(fid,'#PBS -l nodes=1:ppn=1,walltime=2:00:00,mem=8000mb\n');
-    end
-    fprintf(fid,'#PBS -m af\n');
-    fprintf(fid,'#PBS -M %s\n', email_for_notifications);
-    fprintf(fid,'#PBS -t 1-%d\n',num_shuffle);
-
-    expt_dir = pwd;
-    run_dir = expt_dir(1:regexp(expt_dir, 'fwMatch-darpa/','end'));
-    fprintf(fid,'\n#set output and error directories (SSCC example here)\n');
-    fprintf(fid,'#PBS -o localhost:%s/yeti_logs/\n', expt_dir);
-    fprintf(fid,'#PBS -e localhost:%s/yeti_logs/\n', expt_dir);
-
-    fprintf(fid,'\n#Command below is to execute Matlab code for Job Array (Example 4) so that each part writes own output\n');
-    fprintf(fid,'cd %s\n', run_dir);
-    fprintf(fid,'./run.sh %s $PBS_ARRAYID > expt/%s/job_logs/matoutfile.$PBS_ARRAYID\n', experiment_name, experiment_name);
-    fprintf(fid,'#End of script\n');
-
-fclose(fid);
-
 % Kate: we should write the start_jobs.sh script, too, since it includes the experiment name var
     fid = fopen('start_jobs.sh','w');
 

--- a/fwMatch-darpa/src/expt_framework/create_shuffle_config_files.m
+++ b/fwMatch-darpa/src/expt_framework/create_shuffle_config_files.m
@@ -125,21 +125,5 @@ function create_config_files(varargin)
         fclose(fid);
     end
 
-% Kate: we should write the start_jobs.sh script, too, since it includes the experiment name var
-    fid = fopen('start_jobs.sh','w');
-
-    fprintf(fid,'#If you are having problem with line endings use ":set ff=unix" in vim\n\n');
-
-%Kate - I do not want to remove any of the already computed model files; do that manually
-fprintf(fid,'rm -f ./results/result*.mat\n');
-%fprintf(fid,'rm -f ./results/model_calcium.mat\n');
-fprintf(fid,'rm -f ./yeti_logs/*\n');
-fprintf(fid,'rm -f ./job_logs/*\n');
-
-fprintf(fid,'cd ../.. && qsub expt/%s/yeti_config.sh\n', experiment_name);
-fclose(fid);
-%Kate: make sure they are executable:
-system('chmod +x start_jobs.sh yeti_config.sh');
-
 end
 

--- a/fwMatch-darpa/src/expt_framework/create_shuffle_config_files.m
+++ b/fwMatch-darpa/src/expt_framework/create_shuffle_config_files.m
@@ -142,7 +142,6 @@ function create_config_files(varargin)
     end
     fprintf(fid,'#PBS -m af\n');
     fprintf(fid,'#PBS -M %s\n', email_for_notifications);
-    fprintf(fid,'#PBS -V\n');
     fprintf(fid,'#PBS -t 1-%d\n',num_shuffle);
 
     expt_dir = pwd;


### PR DESCRIPTION
Yeti settings are now determined by entries in `crf_parameters.ini`, like all other settings.

Also added a `verbosity` setting to `crf_parameters.ini` that can be used to increase or decrease the amount of informational messages displayed as the algorithm progresses.

Hopefully also fixed the issue with the wrong version of matlab being used on yeti. Should be safe to use an unmodified copy of `fwMatch-darpa/run.sh`.